### PR TITLE
Update schema.sql

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -143,10 +143,11 @@ CREATE TABLE loan (
 CREATE TABLE reservation (
     reservation_id INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     user_id INT UNSIGNED NOT NULL,
-    media_id INT UNSIGNED NOT NULL,
+    copy_id INT UNSIGNED NOT NULL,
     created_date DATETIME NOT NULL DEFAULT NOW(),
     reservation_start DATETIME,
     reservation_end DATETIME,
+    is_active BOOL,
     FOREIGN KEY (user_id) REFERENCES user(user_id),
     FOREIGN KEY (media_id) REFERENCES media(media_id)
 );


### PR DESCRIPTION
reservations should point to copy_id, not media_id due to multiple media_id records having multiple copies

I also added a is_active to facilitate updating reservations when dropping old ones